### PR TITLE
Optimized route matcher to be 22% better #19

### DIFF
--- a/src/Generator/RegexGenerator.php
+++ b/src/Generator/RegexGenerator.php
@@ -74,19 +74,19 @@ class RegexGenerator
     public static function beforeCaching(RouteCompilerInterface $compiler, array $routes): array
     {
         $tree = new static();
-        $indexedRoutes = [];
+        $variables = [];
 
         for ($i = 0; $i < \count($routes); ++$i) {
-            [$pathRegex, $hostsRegex, $variables] = $compiler->compile($route = $routes[$i]);
+            [$pathRegex, $hostsRegex, $regexVars] = $compiler->compile($routes[$i]);
             $pathRegex = \preg_replace('/\?(?|P<\w+>|<\w+>|\'\w+\')/', '', $pathRegex);
 
-            $tree->addRoute($pathRegex, [$pathRegex, $i, [$route, $hostsRegex, $variables]]);
+            $tree->addRoute($pathRegex, [$pathRegex, $i, [$hostsRegex, $regexVars]]);
         }
 
-        $compiledRegex = '~^(?' . $tree->compile(0, $indexedRoutes) . ')$~u';
-        \ksort($indexedRoutes);
+        $compiledRegex = '~^(?' . $tree->compile(0, $variables) . ')$~u';
+        \ksort($variables);
 
-        return [$compiledRegex, $indexedRoutes, $compiler];
+        return [[$compiledRegex, $variables], $routes, $compiler];
     }
 
     /**
@@ -110,7 +110,7 @@ class RegexGenerator
             }
 
             $code .= '|' . \ltrim(\substr($route[0], $prefixLen), '?') . '(*:' . $route[1] . ')';
-            $variables[$route[1]] = $route[2];
+            $variables[$route[1]] = [$route[2]];
         }
 
         return $code;

--- a/src/RouteMatcher.php
+++ b/src/RouteMatcher.php
@@ -101,7 +101,7 @@ final class RouteMatcher implements RouteMatcherInterface
             foreach ($this->routes as $route) {
                 [$pathRegex, $hostsRegex, $variables] = $this->compiler->compile($route);
 
-                if(\preg_match('{^' . $pathRegex . '$}u', $requestPath, $matches, \PREG_UNMATCHED_AS_NULL)) {
+                if (\preg_match('{^' . $pathRegex . '$}u', $requestPath, $matches, \PREG_UNMATCHED_AS_NULL)) {
                     return static::doMatch($method, $uri, [$hostsRegex, $variables, $route], $matches);
                 }
             }

--- a/tests/Matchers/SimpleRouteCompilerTest.php
+++ b/tests/Matchers/SimpleRouteCompilerTest.php
@@ -159,7 +159,7 @@ class SimpleRouteCompilerTest extends TestCase
         [$regexList,] = RegexGenerator::beforeCaching($compiler, $collection->getRoutes());
 
         foreach ($matches as $match) {
-            if (1 === \preg_match($regexList, '/' . \ltrim($match, '/'))) {
+            if (1 === \preg_match($regexList[0], '/' . \ltrim($match, '/'))) {
                 ++$actualCount;
             }
         }


### PR DESCRIPTION
## Description

Improved the existing route matcher to be much faster in matching routes and reduced memory consumption by 54%,

## Motivation and context
The changes made, especially to how cached routes are matched was very necessary. It actually increased performance which was quite surprising to see. The main motivation behind this change is to reduce memory consumption as briefly described in issue #19.

## How has this been tested?

To actual know, if performance has been improved, we benchmark the changes in [Benchmark 1](https://github.com/divineniiquaye/php-routers-benchmarks) and [Benchmark 2](https://github.com/divineniiquaye/benchmark-php-routing)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Deprecation (un-wanted or renamed functionality that should be removed)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING.md](./github/CONTRIBUTING.md)** document.
- [x] I have added tests to cover my changes.
