### PR TITLE
feat: custom route matcher support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
 * [BC Break] Refactored route matching algorithm
 * [BC Break] Updated and Renamed `RouteCollector` class to `RouteCollection`
 * Added benchmark to compare performance over time
+* Added custom route matcher support to the router class
 * Updated routes cache from serialization to var_export
 * Updated PHP minimum version to 7.4 and added PHP 8.1 support
 * Updated README file with documentation of new changes


### PR DESCRIPTION
This PR closes #30 as it adds the requested custom route matcher support into the router class.

## Motivation and context
This will allow developers to fully use any kind of route matcher in the router class.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Deprecation (un-wanted or renamed functionality that should be removed)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING.md](./CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
