### PR TITLE
Fixed regex generator compiling issue

### DIFF
--- a/src/Generator/RegexGenerator.php
+++ b/src/Generator/RegexGenerator.php
@@ -71,22 +71,23 @@ class RegexGenerator
         $code = '';
 
         foreach ($this->items as $route) {
+            $code .= '|';
+
             if ($route instanceof self) {
                 $nested = '(?' . $route->compile($prefixLen + \strlen($prefix = \substr($route->prefix, $prefixLen))) . ')';
 
-                if (\str_starts_with($nested, '(?|?(*')) {
-                    $nested = \substr_replace($nested, '', 0, 3);
+                if (\str_starts_with($nested, '(?|(*')) {
+                    $realPos = \strrpos($realPrefix = $route->staticPrefixes[0], '?');
 
-                    if (\preg_match('#[^a-zA-Z0-9)]+$#', $prefix, $matches)) {
-                        $prefix = \substr_replace($prefix, $matches[0] . '?(?|', -(\strlen($matches[0])));
-                        $nested = \substr($nested, 1);
+                    if ($realPos && '?' === $realPrefix[$realPos]) {
+                        $nested = '?' . $nested;
                     }
                 }
 
-                $grouped = \ltrim($prefix, '?') . $nested;
+                $code .= \ltrim($prefix, '?') . $nested;
+            } else {
+                $code .= \ltrim(\substr($route[0], $prefixLen), '?') . '(*:' . $route[1] . ')';
             }
-
-            $code .= '|' . ($grouped ?? \substr($route[0], $prefixLen) . '(*:' . $route[1] . ')');
         }
 
         return $code;


### PR DESCRIPTION
The generated compiled regex from routes encounters either an invalid regex issue or an optional route match failure

## How has this been tested?
This has been tested using PHPUnit test cases and was encountered in PHP 7.4 and PHP 8.0 except PHP 8.1

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Deprecation (un-wanted or renamed functionality that should be removed)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTING.md](./CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
